### PR TITLE
Optimization

### DIFF
--- a/px4_utils_land/CMakeLists.txt
+++ b/px4_utils_land/CMakeLists.txt
@@ -58,37 +58,37 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 
-add_executable(cmd_to_px4_node src/rl_cmd_to_px4.cc src/utils/Convertor.cc)
-target_link_libraries(cmd_to_px4_node ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(cmd_to_px4_node_land src/rl_cmd_to_px4.cc src/utils/Convertor.cc)
+target_link_libraries(cmd_to_px4_node_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(frame_human_viewer_node src/frame_human_viewer.cc src/utils/Convertor.cc)
-target_link_libraries(frame_human_viewer_node ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(frame_human_viewer_node_land src/frame_human_viewer.cc src/utils/Convertor.cc)
+target_link_libraries(frame_human_viewer_node_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(mocap_re_publish_node src/MocapRePublisher.cc)
-target_link_libraries(mocap_re_publish_node ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(mocap_re_publish_node_land src/MocapRePublisher.cc)
+target_link_libraries(mocap_re_publish_node_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(run_system_id src/run_system_id.cc)
-target_link_libraries(run_system_id ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(run_system_id_land src/run_system_id.cc)
+target_link_libraries(run_system_id_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(px4_ctrl_fsm_node src/px4_ctrl_fsm_node.cc src/utils/PX4CtrlFSM.cc)
-target_link_libraries(px4_ctrl_fsm_node ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(px4_ctrl_fsm_node_land src/px4_ctrl_fsm_node.cc src/utils/PX4CtrlFSM.cc)
+target_link_libraries(px4_ctrl_fsm_node_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(land_command_publisher_node src/land_command_publisher.cc)
-target_link_libraries(land_command_publisher_node ${catkin_LIBRARIES})
+add_executable(land_command_publisher_node_land src/land_command_publisher.cc)
+target_link_libraries(land_command_publisher_node_land ${catkin_LIBRARIES})
 
-add_executable(px4_fsm_interface_node src/px4_fsm_interface.cc)
-target_link_libraries(px4_fsm_interface_node ${catkin_LIBRARIES})
+add_executable(px4_fsm_interface_node_land src/px4_fsm_interface.cc)
+target_link_libraries(px4_fsm_interface_node_land ${catkin_LIBRARIES})
 
 ##zhiyuan: add test executables
 # add_executable(vision_node src/utils/vision_orb.cc)
 # target_link_libraries(vision_node ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 # test
-add_executable(test_mocap_process example/test_mocap.cc src/motion_capture/MocapProcessor.cc)
-target_link_libraries(test_mocap_process ${catkin_LIBRARIES} ${PROJECT_NAME})
+add_executable(test_mocap_process_land example/test_mocap.cc src/motion_capture/MocapProcessor.cc)
+target_link_libraries(test_mocap_process_land ${catkin_LIBRARIES} ${PROJECT_NAME})
 
-add_executable(test_actuator_ctrl example/test_actuator_ctrl.cc)
-target_link_libraries(test_actuator_ctrl ${catkin_LIBRARIES})
+add_executable(test_actuator_ctrl_land example/test_actuator_ctrl.cc)
+target_link_libraries(test_actuator_ctrl_land ${catkin_LIBRARIES})
 
 add_executable(test_imgmatching example/test_imgmatching.cc)
 target_link_libraries(test_imgmatching ${catkin_LIBRARIES} ${PROJECT_NAME})

--- a/px4_utils_land/include/px4_utils_land/ImgMatching.h
+++ b/px4_utils_land/include/px4_utils_land/ImgMatching.h
@@ -35,7 +35,7 @@ private:
     bool first_frame_ = true;
     cv::Point2f last_centroid_;
     cv::Point2f offset_;  // pixel plant
-    float filter_alpha_ = 0.3f; // for centroid filtering
+    float filter_alpha_ = 0.9f; // for centroid filtering
 
     void imageCallback(const sensor_msgs::ImageConstPtr& msg);
     void preprocessImage(const sensor_msgs::ImageConstPtr& msg, cv::Mat& frame, cv::Mat& gray);
@@ -44,7 +44,7 @@ private:
     cv::Point2f projectTargetPoint(const cv::Mat& H, const cv::Point2f& target_point);
     void updateOffsetWithFilter(const cv::Mat& gray, const cv::Point2f& centroid);
     cv::Point2f chooseTargetPoint(const cv::Mat& image);
-    std::string downward_camera_topic_ = "/camera/color/image_raw";
+    std::string downward_camera_topic_ = "/camera/rgb/image_raw";
 
     float z_value; // z value of the hold position 
 

--- a/px4_utils_land/launch/dev_px4_fsm_interface.launch
+++ b/px4_utils_land/launch/dev_px4_fsm_interface.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node pkg="px4_utils_land" type="px4_ctrl_fsm_node" name="px4_ctrl_fsm" output="screen">
+    <node pkg="px4_utils_land" type="px4_ctrl_fsm_node_land" name="px4_ctrl_fsm" output="screen">
         <param name="px4fsm/exec_period" value="0.01" type="double"/>
         <param name="px4fsm/cruise_height" value="2.0" type="double"/>
         <param name="px4fsm/fence_x" value="20.0" type="double"/>
@@ -9,7 +9,7 @@
 	<param name="image_topic" value="/camera/color/image_raw" type="string" />
     </node>
 
-    <node pkg="px4_utils_land" type="px4_fsm_interface_node" name="px4_fsm_interface" output="screen">
+    <node pkg="px4_utils_land" type="px4_fsm_interface_node_land" name="px4_fsm_interface" output="screen">
         <param name="land_topic" value="/trigger_landing" />
     </node>
 </launch>

--- a/px4_utils_land/src/utils/ImgMatching.cc
+++ b/px4_utils_land/src/utils/ImgMatching.cc
@@ -4,7 +4,7 @@ namespace px4_utils_land {
 
 void Imgmatching::init(ros::NodeHandle& nh) {  
     getParamWithWarning(nh, "camera/image_topic", downward_camera_topic_);
-    if(downward_camera_topic_ == "/camera/color/image_raw") {
+    if(downward_camera_topic_ == "/camera/rgb/image_raw") {
         fx_ = 562.94f; // focal length in x
         fy_ = 422.21f; // focal length in y
     }               
@@ -30,10 +30,10 @@ void Imgmatching::imageCallback(const sensor_msgs::ImageConstPtr& msg) {
         cv::Mat frame = cv_bridge::toCvShare(msg, "bgr8")->image;
         cv::Mat gray;
         cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
-
+   
         if (first_frame_) {
             initializeTarget(gray, frame);
-        }
+        } 
 
         std::vector<cv::KeyPoint> frame_kps;
         cv::Mat frame_desc;
@@ -63,6 +63,13 @@ void Imgmatching::imageCallback(const sensor_msgs::ImageConstPtr& msg) {
         cv::circle(frame, centroid_, 5, cv::Scalar(0, 255, 0), -1);
         cv::imshow("Trajectory", frame);
         cv::waitKey(1);
+
+        if (inlier_matches.size() > 50) {  
+            target_image_ = frame.clone();
+            target_point_ = centroid_;
+            target_kps_ = frame_kps;
+            target_desc_ = frame_desc.clone();
+        }
 
     } catch (cv_bridge::Exception& e) {
         ROS_ERROR_STREAM("cv_bridge exception: " << e.what());

--- a/px4_utils_land/src/utils/PX4CtrlFSM.cc
+++ b/px4_utils_land/src/utils/PX4CtrlFSM.cc
@@ -541,7 +541,7 @@ void PX4CtrlFSM::fsmVisionLand() {
 
     // zhiyuan: need actual value of z_
     // u can use a threshold like 0.3 m (depend on camera) to determine if the drone is near the target
-    if ((hold_pos_.z() - image_matcher_->land_pos_z_) < 0.5) {
+    if ((hold_pos_.z() - image_matcher_->land_pos_z_) < 0.1) {
         std::cout << "[PX4 FSM]: Vision becomes blurry. Switching to AUTO.LAND." << std::endl;
         land_initialized = false;
         changeFSMState(AUTO_LAND);
@@ -937,7 +937,7 @@ Eigen::Vector3d PX4CtrlFSM::adjustPositionWithPIControl(const cv::Point2f& offse
     static Eigen::Vector2d integral_error(0.0, 0.0);
     static ros::Time last_update_time;
     
-    const double kp = 0.02;  // Proportional gain
+    const double kp = 0.01;  // Proportional gain
     const double ki = 0.0001; // Integral gain
     const double max_integral = 1.0; // Anti-windup limit
     const double max_correction = 0.5; // Maximum position correction per cycle


### PR DESCRIPTION
Optimized the logic of Imgmatching
Solved the problem of local matching
The working height of downward-looking cameras is now extended to 10cm - 10m

Notice:
go to ImgMatching.cc and set the value of downward_camera_topic:
1."/camera/rgb/image_raw" for simulation
2."/camera/color/image_raw" for D405 camera
